### PR TITLE
Fix typo in use of sizeof()

### DIFF
--- a/ngx_http_strip_filter_module.c
+++ b/ngx_http_strip_filter_module.c
@@ -145,7 +145,7 @@ ngx_http_strip_header_filter(ngx_http_request_t *r)
         return ngx_http_next_header_filter(r);
     }
 
-    if (ngx_strncasecmp(r->headers_out.content_type.data, (u_char *)"text/html", sizeof("text/html" - 1)) != 0) {
+    if (ngx_strncasecmp(r->headers_out.content_type.data, (u_char *)"text/html", sizeof("text/html") - 1) != 0) {
         return ngx_http_next_header_filter(r);
     }
 


### PR DESCRIPTION
Due to the misplaced closing paranthesis in sizeof("text/html" - 1), the string
comparison with the content type would compare only the first 4 bytes, thus
potentially filtering even non-HTML content. This is a simple change to fix
that issue.
